### PR TITLE
use the point notation for lat/lng

### DIFF
--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -203,7 +203,7 @@ final class Address
     public function getGeoLocation()
     {
         // native geo handling
-        if ($this->isGeoStorageUsingNatviePoint()) {
+        if ($this->isGeoStorageUsingNativePoint()) {
             $point = $this->dataBag->get('address.point');
             if (empty($point) || empty($point['coordinates']) || empty($point['coordinates'][0]) || empty($point['coordinates'][1])) {
                 return null;
@@ -237,7 +237,7 @@ final class Address
         $this->guardAgainstInvalidLatLong($latitude, $longitude);
 
         // native geo handling
-        if ($this->isGeoStorageUsingNatviePoint()) {
+        if ($this->isGeoStorageUsingNativePoint()) {
             $this->dataBag->set('address.point', [
                 'coordinates' => [
                     0 => $longitude,
@@ -250,7 +250,7 @@ final class Address
         $this->dataBag->set('address.longitude', $longitude);
     }
 
-    private function isGeoStorageUsingNatviePoint()
+    private function isGeoStorageUsingNativePoint()
     {
         return !empty($this->dataBag->get('address.point'));
     }

--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -202,6 +202,19 @@ final class Address
      */
     public function getGeoLocation()
     {
+        // native geo handling
+        if ($this->isGeoStorageUsingNatviePoint()) {
+            $point = $this->dataBag->get('address.point');
+            if (empty($point) || empty($point['coordinates']) || empty($point['coordinates'][0]) || empty($point['coordinates'][1])) {
+                return null;
+            }
+            return [
+                'lat' => (float)$point['coordinates'][1],
+                'lng' => (float)$point['coordinates'][0],
+            ];
+        }
+
+        // `old`-style
         $lat = $this->dataBag->get('address.latitude');
         $lng = $this->dataBag->get('address.longitude');
         if (!isset($lat, $lng)) {
@@ -223,8 +236,23 @@ final class Address
         $longitude = (float)$longitude;
         $this->guardAgainstInvalidLatLong($latitude, $longitude);
 
+        // native geo handling
+        if ($this->isGeoStorageUsingNatviePoint()) {
+            $this->dataBag->set('address.point', [
+                'coordinates' => [
+                    0 => $longitude,
+                    1 => $latitude,
+                ],
+            ]);
+            return;
+        }
         $this->dataBag->set('address.latitude', $latitude);
         $this->dataBag->set('address.longitude', $longitude);
+    }
+
+    private function isGeoStorageUsingNatviePoint()
+    {
+        return !empty($this->dataBag->get('address.point'));
     }
 
     /**

--- a/tests/Entity/AddressTest.php
+++ b/tests/Entity/AddressTest.php
@@ -57,7 +57,6 @@ class AddressTest extends TestCase
             ['city', 'Zandvoort'],
             ['countryCode', 'NL'],
             ['type', 'work'],
-            ['type', 'work'],
         ];
     }
 
@@ -70,6 +69,87 @@ class AddressTest extends TestCase
         $this->assertSame([
             'lat' => $lat,
             'lng' => $lng,
+        ], $address->getGeoLocation());
+    }
+
+    public function test_can_get_geolocation_using_point()
+    {
+        $lat = 52.36498073;
+        $lng = 4.55567032;
+        $address = Address::fromAddressData([
+            'point' => [
+                'coordinates' => [
+                    0 => $lng,
+                    1 => $lat,
+                ]
+            ],
+        ]);
+        $this->assertSame([
+            'lat' => $lat,
+            'lng' => $lng,
+        ], $address->getGeoLocation());
+    }
+
+    public function test_can_get_geolocation_using_old_style()
+    {
+        // old style
+        $lat = 52.36498073;
+        $lng = 4.55567032;
+        $address = Address::fromAddressData([
+            'latitude' => $lat,
+            'longitude' => $lng,
+        ]);
+        $this->assertSame([
+            'lat' => $lat,
+            'lng' => $lng,
+        ], $address->getGeoLocation());
+    }
+
+    public function test_can_get_geolocation_prefers_point()
+    {
+        // old style
+        $pointLat = 52.36498073;
+        $pointLng = 4.55567032;
+        $oldLat = 1.55567032;
+        $oldLng = 55.55567032;
+        $address = Address::fromAddressData([
+            'point' => [
+                'coordinates' => [
+                    0 => $pointLng,
+                    1 => $pointLat,
+                ]
+            ],
+            'latitude' => $oldLat,
+            'longitude' => $oldLng,
+        ]);
+        $this->assertSame([
+            'lat' => $pointLat,
+            'lng' => $pointLng,
+        ], $address->getGeoLocation());
+    }
+
+    public function test_can_set_geolocation_using_point()
+    {
+        $newLat = 52.36498073;
+        $newLng = 4.55567032;
+        $oldLat = 1.55567032;
+        $oldLng = 55.55567032;
+        $address = Address::fromAddressData([
+            'point' => [
+                'coordinates' => [
+                    0 => $oldLng,
+                    1 => $oldLat,
+                ]
+            ],
+        ]);
+        $this->assertSame([
+            'lat' => $oldLat,
+            'lng' => $oldLng,
+        ], $address->getGeoLocation());
+        $address->setGeoLocation($newLat, $newLng);
+        $this->assertSame([
+            'lat' => $newLat,
+            'lng' => $newLng,
         ], $address->getGeoLocation());
     }
 


### PR DESCRIPTION
If the address data already has 'point', then use it. The only issue is using it on *new* addresses... It can't be detected, thus the 'isGeoStorageUsingNatviePoint'-method shoudl allow for `outside` injection?

@TODO discuss this with @misha to figure out the injection / outside setting of the 'usePoint'-stuff (as that is the better/new/official/non-deprecated way)
(`use the Point luke!`)

//part of / fixes #4