### PR TITLE
fixed: make sure when updating that the downstream communibase-databag also gets updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": ">=7.1",
-    "kingsquare/communibase-databag": "^1.1",
+    "kingsquare/communibase-databag": "^1.1.4",
     "ext-json": "*",
     "giggsey/libphonenumber-for-php": "^8.12"
   },


### PR DESCRIPTION
when already installed and updating from i.e. v2 to v3 the databag dependency will not get updated as v2 used ^1.1 and the v3 uses ^1.1 and the composer lock already has a ^1.1 which may not be the one this package depends on or not the one containing recent fixes...

fixes #6